### PR TITLE
Issue with adding underscores to output

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -77,7 +77,7 @@ function doTheThing() {
   // Get the input & options here
   inputText = document.getElementById('input-text').value;
   extension = document.querySelector('input[name="extension"]:checked').value;
-  if (!document.querySelector('input[name="underscore"]').checked) { underscore = ''; }
+  (!document.querySelector('input[name="underscore"]').checked) ? underscore = '' : underscore = '_';
 
   var lines = inputText.split('\n'); //split up the lines in the string into a lines array
 


### PR DESCRIPTION
The Prefix files with `"_"` checkbox defaults to checked, so if you hit submit it generates the output with `"_"`, then if you uncheck it and hit submit it generates the output again but with `""`. If you check the box one more time intending to use `"_"`, the output uses `""`, and will never use anything other than `""` no matter how many times you check/uncheck/submit from here on.

Added else statement so it always sets the variable `underscore` to something when `doTheThing();` runs.

Also I have another branch that I was playing around with refactoring the functions that create the shell commands (I accidentally stayed up until 3am because I was having so much fun!). You can create folders and subfolders and touch deeper files while not jumping around `cd`ing into directories by doing this:

``` ShellSession
# from your mini-framework
mkdir base base/vars base/helpers theme regions modules components pages;
touch base/_reset.scss base/vars/_color.scss .......... pages/_contact.scss _to-do.scss;
```

Would you like to take a look at a PR for this? Which branch should I do it off of (I did this one off of your gh-pages because it had your latest commits)

and Happy Birthday @una! :balloon: :)

> ![Jerry: Kramer, these balloons aren't gonna stay filled 'til New Year's?! Kramer: Those aren't for New Year's, those are my everyday balloons..](https://cloud.githubusercontent.com/assets/2252884/8841510/0c017f34-30b4-11e5-9ddf-86242baadf8b.jpg)
