### PR TITLE
Simplify the commands used to create files and directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Input:
 Default Output:
 
 ```sh
-mkdir utils;cd utils;touch _variables.scss;touch _functions.scss;touch _mixins.scss;touch _placeholders.scss;cd ../;mkdir base;cd base;touch _reset.scss;touch _typography.scss;cd ../;mkdir layout;cd layout;touch _navigation.scss;touch _grid.scss;touch _header.scss;touch _footer.scss;touch _sidebar.scss;touch _forms.scss;cd ../;mkdir components;cd components;touch _buttons.scss;touch _carousel.scss;touch _cover.scss;touch _dropdown.scss;cd ../;mkdir pages;cd pages;touch _home.scss;touch _contact.scss;cd ../;mkdir themes;cd themes;touch _theme.scss;touch _admin.scss;
+mkdir base/ components/ layout/ pages/ themes/ utils/; touch base/_reset.scss base/_typography.scss components/_buttons.scss components/_carousel.scss components/_cover.scss components/_dropdown.scss layout/_footer.scss layout/_forms.scss layout/_grid.scss layout/_header.scss layout/_navigation.scss layout/_sidebar.scss pages/_contact.scss pages/_home.scss themes/_admin.scss themes/_theme.scss utils/_functions.scss utils/_mixins.scss utils/_placeholders.scss utils/_variables.scss;
 ```
 
 It works for files in the same directory and multiple subdirectories:
@@ -57,7 +57,7 @@ Input:
 Output:
 
 ```sh
-touch _file1.scss;mkdir dir1;cd dir1;touch _file2.scss;mkdir dir2;cd dir2;touch _file3.scss;cd ../;cd ../;mkdir dir3;cd dir3;mkdir dir4;cd dir4;touch _file5.scss;cd ../;cd ../;
+mkdir dir1/ dir1/dir2/ dir3/dir4/; touch _file1.scss dir1/_file2.scss dir1/dir2/_file3.scss dir3/dir4/_file5.scss;
 ```
 
 ## Options
@@ -86,4 +86,3 @@ TO-DO
 - [x] create cli so we can go `sass-director file-name.scss`
 - [ ] Options for sass and underscore in node module
 - [ ] Add shellscript docs
-

--- a/scripts.js
+++ b/scripts.js
@@ -3,11 +3,10 @@ var extension = '.scss', //default
 
 function getDirectoryNames(cleanNames) {
   //returns a string of sorted directory names seperated by spaces
-
   var repeatedDirNames = cleanNames.map(function(name) {
     //maps a name with the filename part removed (part after last slash)
     //or '' if the name is a filename (no slashes in the name)
-    return name.substr(0, name.lastIndexOf('/')+1)
+    return name.substr(0, name.lastIndexOf('/'));
   });
 
   var dirNames = [];
@@ -18,17 +17,16 @@ function getDirectoryNames(cleanNames) {
       dirNames.push(name);
   });
 
-  return dirNames.sort().join(' ').trim();
+  return dirNames.join(' ').trim();
 }
 
 function getFileNames(cleanNames){
   //returns a string of sorted filenames seperated by spaces
-
   var fileNames = cleanNames.map(function(name){
     var file = name.substr(name.lastIndexOf('/')+1) || name;
     var path = name.substr(0, name.lastIndexOf('/')+1) || '';
-    file = underscore + file + extension;
-    return path + file;
+
+    return path + underscore + file + extension;
   });
 
   return fileNames.sort().join(' ').trim();


### PR DESCRIPTION
As explained in https://github.com/una/sass-director/pull/25

> You can create folders and subfolders and touch deeper files while not jumping around `cd`ing into directories by doing this:
> 
> ``` ShellSession
> # from your mini-framework
> mkdir base base/vars base/helpers theme regions modules components pages;
> touch base/_reset.scss base/vars/_color.scss .......... pages/_contact.scss _to-do.scss;
> ```
